### PR TITLE
Increase memory factor kraken2_pe_minimal

### DIFF
--- a/workflows/kraken2_pe_minimal.wdl
+++ b/workflows/kraken2_pe_minimal.wdl
@@ -50,7 +50,7 @@ task kraken2 {
   }
 
   Int disk_size = ceil(size(read1, "GB") + size(read2, "GB") + 2*size(kraken2_db, "GB")) + 20
-  Int memory = ceil(2*size(kraken2_db, "GB"))
+  Int memory = ceil(4*size(kraken2_db, "GB"))
 
   command <<<
     echo $(kraken2 --version 2>&1) | sed 's/^.*Kraken version //;s/ .*$//' | tee VERSION


### PR DESCRIPTION
Double memory factor to avoid out of memory problems on Terra. tested on test_meta_0012 on 3 samples that were failing using original memory allocation with 8 CPUs